### PR TITLE
Added ngModule and updated the examples app to use it

### DIFF
--- a/examples/app/app.module.ts
+++ b/examples/app/app.module.ts
@@ -1,12 +1,12 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
+import {ColorPickerModule} from 'angular2-color-picker';
+
 import {AppComponent} from './app.component';
-import {ColorPickerService} from 'angular2-color-picker';
 
 @NgModule({
-    declarations: [AppComponent],
-    imports: [BrowserModule],    
     bootstrap: [AppComponent],
-    providers: [ColorPickerService]
+    declarations: [AppComponent],
+    imports: [BrowserModule, ColorPickerModule]
 })
 export class AppModule { }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     },
     "license": "MIT",
     "dependencies": {
+        "@angular/common": "2.0.0-rc.5",
         "@angular/core": "2.0.0-rc.5",
-        "rxjs": "5.0.0-beta.6",
+        "rxjs": "5.0.0-beta.11",
         "zone.js": "^0.6.12"
     },
     "devDependencies": {

--- a/src/color-picker.directive.ts
+++ b/src/color-picker.directive.ts
@@ -151,8 +151,7 @@ export class SliderDirective {
 @Component({
     selector: 'color-picker',
     templateUrl: './templates/default/color-picker.html',
-    styleUrls: ['./templates/default/color-picker.css'],
-    directives: [SliderDirective, TextDirective]
+    styleUrls: ['./templates/default/color-picker.css']
 })
 export class DialogComponent implements OnInit {
     private hsva: Hsva;

--- a/src/color-picker.module.ts
+++ b/src/color-picker.module.ts
@@ -1,0 +1,13 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+
+import {ColorPickerService} from './color-picker.service';
+import {ColorPickerDirective, DialogComponent, TextDirective, SliderDirective} from './color-picker.directive';
+
+@NgModule({
+    imports: [CommonModule],
+    providers: [ColorPickerService],
+    declarations: [ColorPickerDirective, DialogComponent, TextDirective, SliderDirective],
+    exports: [CommonModule, ColorPickerDirective, DialogComponent, TextDirective, SliderDirective]
+})
+export class ColorPickerModule {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './classes';
-export * from './color-picker.service';
 export * from './color-picker.directive';
+export * from './color-picker.module';
+export * from './color-picker.service';


### PR DESCRIPTION
This will break the color picker for older than RC5 Angular 2, but is needed to work with the upcoming Angular 2 RC6 release.