### PR TITLE
chore(package): cleanup package, module and build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,13 +1,10 @@
-examples/app/*.js
-examples/app/*.d.ts
+examples
+node_modules
+typings
 
-examples/node_modules/*
-examples/typings/*
-examples/npm-debug.log
-
-node_modules/*
-typings/*
+_config.yml
 npm-debug.log
+typings.json
 
 .sass-cache
 nbproject/*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var inlineNg2Template = require('gulp-inline-ng2-template');
 var runSequence = require('run-sequence');
 
 gulp.task('clean', function () {
-    return del.sync('lib/**/*');
+    return del.sync(['index.+(js|js.map|d.ts)', 'lib/**/*']);
 });
 
 gulp.task('copy:assets', function () {
@@ -19,7 +19,7 @@ gulp.task('copy:assets', function () {
 
 gulp.task("typings",function(){
     var stream = gulp.src("./typings.json")
-        .pipe(gulpTypings()); 
+        .pipe(gulpTypings());
     return stream;
 });
 
@@ -37,7 +37,7 @@ gulp.task('compile', function () {
             .pipe(tsc(tscConfig.compilerOptions))
     r.dts.pipe(gulp.dest('lib'));
     r.js.pipe(gulp.dest('lib'));
-    
+
     return r.pipe(sourcemaps.write('.'))
             .pipe(gulp.dest('lib'));
 });
@@ -48,7 +48,7 @@ gulp.task('compile:index', function () {
             .pipe(tsc(tscConfig.compilerOptions))
     r.dts.pipe(gulp.dest('.'));
     r.js.pipe(gulp.dest('.'));
-    
+
     return r.pipe(sourcemaps.write('.'))
             .pipe(gulp.dest('.'));
 });
@@ -68,7 +68,7 @@ gulp.task('fake', function (callback) {
 
 gulp.task('copy:fake', function () {
     return gulp.src(['lib/**/*'])
-           .pipe(gulp.dest('examples/node_modules/angular2-color-picker/lib'));           
+           .pipe(gulp.dest('examples/node_modules/angular2-color-picker/lib'));
 });
 
 gulp.task('copy:index', function () {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
     "description": "Angular 2 Color Picker Directive, no dependences required.",
     "version": "1.2.0",
     "main": "index.js",
-    "scripts": {       
+    "scripts": {
         "build": "gulp"
     },
     "license": "MIT",
-    "dependencies": {
+    "peerDependencies": {
         "@angular/common": "2.0.0-rc.6",
         "@angular/core": "2.0.0-rc.6",
         "@angular/platform-browser": "2.0.0-rc.6",
@@ -27,5 +27,23 @@
         "run-sequence": "^1.2.2",
         "typescript": "^1.8.10",
         "typings": "^1.0.4"
+    },
+    "module": "index.js",
+    "typings": "./index.d.ts",
+    "author": "Alberto Pujante <alberplz@gmail.com>",
+    "keywords": [
+        "angular",
+        "angular2",
+        "angularjs-color-picker",
+        "angular2-color-picker",
+        "color",
+        "color-picker"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Alberplz/angular2-color-picker.git"
+    },
+    "bugs": {
+        "url": "https://github.com/Alberplz/angular2-color-picker/issues"
     }
 }

--- a/src/color-picker.module.ts
+++ b/src/color-picker.module.ts
@@ -8,6 +8,6 @@ import {ColorPickerDirective} from './color-picker.directive';
     imports: [CommonModule],
     providers: [ColorPickerService],
     declarations: [ColorPickerDirective],
-    exports: [CommonModule, ColorPickerDirective]
+    exports: [ColorPickerDirective]
 })
 export class ColorPickerModule {}


### PR DESCRIPTION
* add more fields to describe package in NPM
* cleanup files exported as NPM package
* don't re-export ng2 CommonModule
* delete index.* output files on build clean