### PR TITLE
Fix cpWidth setting and add change detection for cpPresetColors

### DIFF
--- a/src/color-picker.directive.ts
+++ b/src/color-picker.directive.ts
@@ -317,13 +317,13 @@ export class DialogComponent implements OnInit, AfterViewInit {
 
     ngAfterViewInit() {
         if (this.cpWidth != 230) {
-          let alphaWidth = this.alphaSlider.nativeElement.offsetWidth;
-          let hueWidth = this.hueSlider.nativeElement.offsetWidth;
-          this.sliderDimMax = new SliderDimension(hueWidth, this.cpWidth, 130, alphaWidth);
+            let alphaWidth = this.alphaSlider.nativeElement.offsetWidth;
+            let hueWidth = this.hueSlider.nativeElement.offsetWidth;
+            this.sliderDimMax = new SliderDimension(hueWidth, this.cpWidth, 130, alphaWidth);
 
-          this.update(false);
+            this.update(false);
 
-          this.cdr.detectChanges();
+            this.cdr.detectChanges();
         }
     }
 

--- a/src/color-picker.directive.ts
+++ b/src/color-picker.directive.ts
@@ -1,4 +1,4 @@
-import {Component, OnChanges, Directive, Input, Output, ViewContainerRef, ElementRef, EventEmitter, OnInit, ViewChild} from '@angular/core';
+import {Component, OnChanges, Directive, Input, Output, ViewContainerRef, ElementRef, EventEmitter, OnInit, AfterViewInit, ViewChild, ChangeDetectorRef} from '@angular/core';
 import {ColorPickerService} from './color-picker.service';
 import {Rgba, Hsla, Hsva, SliderPosition, SliderDimension} from './classes';
 import {NgModule, Compiler, ReflectiveInjector} from '@angular/core';
@@ -58,6 +58,11 @@ export class ColorPickerDirective implements OnInit, OnChanges {
 
             }
             this.ignoreChanges = false;
+        }
+        if (changes.cpPresetLabel || changes.cpPresetColors) {
+            if (this.dialog) {
+                this.dialog.setPresetConfig(this.cpPresetLabel, this.cpPresetColors);
+            }
         }
     }
 
@@ -203,7 +208,7 @@ export class SliderDirective {
     styleUrls: ['./templates/default/color-picker.css']
 })
 
-export class DialogComponent implements OnInit {
+export class DialogComponent implements OnInit, AfterViewInit {
     private hsva: Hsva;
     private rgbaText: Rgba;
     private hslaText: Hsla;
@@ -253,7 +258,7 @@ export class DialogComponent implements OnInit {
 
     @ViewChild('dialogPopup') dialogElement: any;
 
-    constructor(private el: ElementRef, private service: ColorPickerService) { }
+    constructor(private el: ElementRef, private cdr : ChangeDetectorRef, private service: ColorPickerService) { }
 
     setDialog(instance: any, elementRef: ElementRef, color: any, cpPosition: string, cpPositionOffset: string,
         cpPositionRelativeToArrow: boolean, cpOutputFormat: string, cpPresetLabel: string, cpPresetColors: Array<string>,
@@ -280,6 +285,9 @@ export class DialogComponent implements OnInit {
         this.cpOKButtonText = cpOKButtonText;
         this.cpHeight = parseInt(cpHeight);
         this.cpWidth = parseInt(cpWidth);
+        if (!this.cpWidth) {
+            this.cpWidth = elementRef.nativeElement.offsetWidth;
+        }
         this.cpIgnoredElements = cpIgnoredElements;
         this.cpDialogDisplay = cpDialogDisplay;
         if (this.cpDialogDisplay === 'inline') {
@@ -307,8 +315,25 @@ export class DialogComponent implements OnInit {
         this.openDialog(this.initialColor, false);
     }
 
+    ngAfterViewInit() {
+        if (this.cpWidth != 230) {
+          let alphaWidth = this.alphaSlider.nativeElement.offsetWidth;
+          let hueWidth = this.hueSlider.nativeElement.offsetWidth;
+          this.sliderDimMax = new SliderDimension(hueWidth, this.cpWidth, 130, alphaWidth);
+
+          this.update(false);
+
+          this.cdr.detectChanges();
+        }
+    }
+
     setInitialColor(color: any) {
         this.initialColor = color;
+    }
+
+    setPresetConfig(cpPresetLabel: string, cpPresetColors: Array<string>) {
+        this.cpPresetLabel = cpPresetLabel;
+        this.cpPresetColors = cpPresetColors;
     }
 
     openDialog(color: any, emit: boolean = true) {

--- a/src/templates/default/color-picker.html
+++ b/src/templates/default/color-picker.html
@@ -65,7 +65,7 @@
        <div *ngFor="let color of cpPresetColors" class="preset-color" [style.backgroundColor]="color" (click)="setColorFromString(color)"></div>
     </div>
 
-    <div class="button-area">
+    <div *ngIf="cpOKButton || cpCancelButton" class="button-area">
         <button *ngIf="cpOKButton" type="button" class="{{cpOKButtonClass}}" (click)="oKColor()">{{cpOKButtonText}}</button>
         <button *ngIf="cpCancelButton" type="button" class="{{cpCancelButtonClass}}" (click)="cancelColor()">{{cpCancelButtonText}}</button>
     </div>

--- a/src/templates/default/color-picker.scss
+++ b/src/templates/default/color-picker.scss
@@ -21,6 +21,7 @@
 }
 
 .color-picker{
+    overflow: hidden;
     cursor: default;
     width: 230px;
     height: auto;


### PR DESCRIPTION
Last version broke the custom width setting. This fixes that by adding slider initialization after view init when using custom value. This also adds support for cpWidth 'auto' which means that width of the trigger element is used (useful for when showing dialog on bottom and you want the width to match the trigger element). 

I also added change detection and updating of preset settings since those can change after dialog has been opened for the first time.
