### PR TITLE
Added "cpColorChangeOnInit" to allow disabling of changeEvent OnInit. Defaults to true

### DIFF
--- a/lib/color-picker.directive.ts
+++ b/lib/color-picker.directive.ts
@@ -35,6 +35,7 @@ export class ColorPickerDirective implements OnInit, OnChanges {
     @Input('cpDialogDisplay') cpDialogDisplay: string = 'popup';
     @Input('cpSaveClickOutside') cpSaveClickOutside: boolean = true;
     @Input('cpAlphaChannel') cpAlphaChannel: string = 'hex6';
+	@Input('cpColorChangeOnInit') cpColorChangeOnInit: boolean = true;
 
     private dialog: any;
     private created: boolean;
@@ -67,7 +68,9 @@ export class ColorPickerDirective implements OnInit, OnChanges {
         if (hsva == null) {
             hsva = this.service.stringToHsva(this.cpFallbackColor);
         }
-        this.colorPickerChange.emit(this.service.outputFormat(hsva, this.cpOutputFormat, this.cpAlphaChannel === 'hex8'));
+		if(this.cpColorChangeOnInit == true){
+			this.colorPickerChange.emit(this.service.outputFormat(hsva, this.cpOutputFormat, this.cpAlphaChannel === 'hex8'));
+		}
     }
 
     onClick() {

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Default option is the first item.
 [cpIgnoredElements]="[]"
 [cpDialogDisplay]="'popup,' 'inline'"
 [cpAlphaChannel]="'hex6', 'hex8', 'disabled'"
+[cpColorChangeOnInit]="true, false"
 ```
 
 #Extra content


### PR DESCRIPTION
The current functionality fires as soon as the directive is made available.  this prevents the user from applying a 'transparently/no color" to the target.

By adding this Input parameter:

1. The existing default behavior remains the same and fires OnInit.  
2. If someone has a need of either of the following uses case, they can make use of it.
- A. Force the user to choose a color
- B. Considers "no Color" as a valid choice. 

Thank you